### PR TITLE
Add Line Breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 ## Anxious in Brooklyn
 A blog about overcoming anxiety in New York through action, powered by [Gatsby]https://www.gatsbyjs.com/)
 
-**Running in development**
+**Running in development**  
 `gatsby develop`
 
-**Content**
-All content is hosted on [Contentful](https://www.contentful.com/).
-
+**Content**  
+All content is hosted on [Contentful](https://www.contentful.com/).  
 After updating content, you must restart the Gatsby server in order to see changes.
 
-**Deploying**
+**Deploying**  
 Deploying through [Netlify](https://www.netlify.com/) by pushing to master.


### PR DESCRIPTION
According to the [Github Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet), "to have a line break without a paragraph, you will need to use two trailing spaces." This seems very odd to me, but let's see if it works.